### PR TITLE
Add config options for setting Admin Router gRPC port 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ module "dcos-security-groups" {
 | num\_public\_agents | Specify the amount of public agents. These agents will host marathon-lb and edgelb | string | n/a | yes |
 | resource\_group\_name | Name of the azure resource group | string | n/a | yes |
 | subnet\_range | Private IP space to be used in CIDR format | string | n/a | yes |
+| adminrouter\_grpc\_proxy\_port |  | string | `"12379"` | no |
 | hostname\_format | Format the hostname inputs are index+1, region, cluster_name | string | `"nsg-%[1]d-%[2]s"` | no |
 | name\_prefix | Name Prefix | string | `""` | no |
 | public\_agents\_additional\_ports | List of additional ports allowed for public access on public agents (80 and 443 open by default) | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,18 @@ resource "azurerm_network_security_group" "masters" {
   }
 
   security_rule {
+    name                       = "grpcRule"
+    priority                   = 112
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "${var.adminrouter_grpc_proxy_port}"
+    destination_address_prefix = "*"
+    source_address_prefixes    = ["${var.admin_ips}"]
+  }
+
+  security_rule {
     name                       = "8080Rule"
     priority                   = 150
     direction                  = "Inbound"

--- a/variables.tf
+++ b/variables.tf
@@ -62,3 +62,8 @@ variable "num_private_agents" {
 variable "num_public_agents" {
   description = "Specify the amount of public agents. These agents will host marathon-lb and edgelb"
 }
+
+variable "adminrouter_grpc_proxy_port" {
+  description = ""
+  default     = 12379
+}


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476